### PR TITLE
remove ZWSP character

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
                     "title": "Preview Exclude",
                     "description": "Exclude Glob pattern for `Preview All Svg`",
                     "type": "string",
-                    "default": "**​/node_modules/**"
+                    "default": "**/node_modules/**"
                 },
                 "svg.pathDataHighlight": {
                     "description": "Show Grammar Highlight in path data",


### PR DESCRIPTION
Random utf8 invisible space character snuck into the default settings JSON

(Hex "\xE2 \x80 \x8B")